### PR TITLE
chore: enable Cloudflare custom domains in wrangler config

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,12 +1,9 @@
 {
   "$schema": "./node_modules/wrangler/config-schema.json",
   // Bayan Flow — static Vite SPA on Cloudflare Workers (not Pages).
-  // Migration phases:
-  //   1. Deploy to *.workers.dev only (no custom domains in routes below).
-  //   2. Smoke-test on workers.dev URLs.
-  //   3. Uncomment staging routes → repoint dev.bayanflow.com in Cloudflare dashboard.
-  //   4. Uncomment production routes → repoint bayanflow.com.
-  // Keep Netlify projects alive as rollback until both domains are stable.
+  // Phases 1–2 complete (workers.dev smoke-tested).
+  // Phase 3–4: custom domains below — deploy then repoint DNS in Cloudflare dashboard.
+  // Keep Netlify projects alive as rollback until both domains are stable ~2 weeks.
   "name": "bayan-flow",
   "compatibility_date": "2026-06-23",
   "workers_dev": true,
@@ -19,14 +16,17 @@
     "staging": {
       "name": "bayan-flow-staging",
       "workers_dev": true,
-      "preview_urls": true
-      // "routes": [{ "pattern": "dev.bayanflow.com", "custom_domain": true }]
+      "preview_urls": true,
+      "routes": [{ "pattern": "dev.bayanflow.com", "custom_domain": true }]
     },
     "production": {
       "name": "bayan-flow",
       "workers_dev": true,
-      "preview_urls": true
-      // "routes": [{ "pattern": "bayanflow.com", "custom_domain": true }]
+      "preview_urls": true,
+      "routes": [
+        { "pattern": "bayanflow.com", "custom_domain": true },
+        { "pattern": "www.bayanflow.com", "custom_domain": true }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Contribution workflow

- [x] **Base branch is `develop`:** This PR targets **`develop`**, not `main`.
- [x] **Guidelines and docs:** Read CONTRIBUTING.md and relevant docs.
- [x] **This template:** PR template structure kept; sections below filled in.

## Description

Enables custom-domain routes in `wrangler.jsonc` for the Netlify → Cloudflare migration (phases 3–4). `workers.dev` smoke tests are already done; this wires the Workers to the real hostnames so deploys can attach `dev.bayanflow.com` and `bayanflow.com`.

**Note:** Merging to `develop` only updates the **staging** worker (`dev.bayanflow.com`). Production routes apply after this reaches `main` via a follow-up merge.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI improvement
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or improvement
- [x] 🔧 Chore (maintenance, dependencies, etc.)

## Related Issues

Fixes #

## Changes Made

- Uncomment / add `routes` on `env.staging` → `dev.bayanflow.com`
- Uncomment / add `routes` on `env.production` → `bayanflow.com`, `www.bayanflow.com`
- Update `wrangler.jsonc` comments to reflect phases 1–2 complete

## Algorithm Details (if applicable)

N/A

## Testing

- [x] `workers.dev` URLs smoke-tested before this change
- [ ] After merge: **Deploy (Cloudflare Workers)** green on `develop`
- [ ] After merge: confirm `dev.bayanflow.com` appears on **bayan-flow-staging** → Domains tab
- [ ] DNS cutover for `dev.bayanflow.com` (manual, post-deploy)
- [ ] Production domains after merge to `main` + deploy + DNS

### Test Results

Config-only change; validation is deploy + live URL check.

## Screenshots/GIFs

N/A

## Code Quality

- [x] Minimal diff; no application code touched
- [x] Matches existing `wrangler.jsonc` environment layout

## Performance Impact

- [x] No performance impact

## Accessibility

- [x] N/A

## Breaking Changes

- None in repo code. **DNS cutover** to Cloudflare is a manual ops step after deploy; Netlify remains rollback until domains are verified (~2 weeks).

## Checklist

- [x] Contribution workflow checklist completed
- [ ] CI green on PR
- [ ] Staging deploy succeeds with custom domain attached
- [ ] Follow-up: merge to `main` for production routes + `bayanflow.com` DNS

## Additional Notes

### After this PR merges to `develop`

1. Confirm **Deploy (Cloudflare Workers)** succeeds
2. **bayan-flow-staging** → Domains → `dev.bayanflow.com` active
3. Update DNS (remove Netlify records if still pointing there)
4. Smoke https://dev.bayanflow.com

### Production (`bayanflow.com`)

Requires the same `wrangler.jsonc` on `main` (merge `develop` → `main` when staging is verified).

### Rollback

Point DNS back to Netlify; Netlify projects kept intentionally.

---

**Reviewer Guidelines:**
- Verify route patterns match live hostnames only
- No app or registry changes expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration with phased rollout descriptions, including domain repointing guidance and rollback period information.
  * Configured custom domain routes for staging (dev.bayanflow.com) and production (bayanflow.com, www.bayanflow.com) environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->