### PR TITLE
chore: merge develop to main for Cloudflare production custom domains

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,12 +1,9 @@
 {
   "$schema": "./node_modules/wrangler/config-schema.json",
   // Bayan Flow — static Vite SPA on Cloudflare Workers (not Pages).
-  // Migration phases:
-  //   1. Deploy to *.workers.dev only (no custom domains in routes below).
-  //   2. Smoke-test on workers.dev URLs.
-  //   3. Uncomment staging routes → repoint dev.bayanflow.com in Cloudflare dashboard.
-  //   4. Uncomment production routes → repoint bayanflow.com.
-  // Keep Netlify projects alive as rollback until both domains are stable.
+  // Phases 1–2 complete (workers.dev smoke-tested).
+  // Phase 3–4: custom domains below — deploy then repoint DNS in Cloudflare dashboard.
+  // Keep Netlify projects alive as rollback until both domains are stable ~2 weeks.
   "name": "bayan-flow",
   "compatibility_date": "2026-06-23",
   "workers_dev": true,
@@ -19,14 +16,17 @@
     "staging": {
       "name": "bayan-flow-staging",
       "workers_dev": true,
-      "preview_urls": true
-      // "routes": [{ "pattern": "dev.bayanflow.com", "custom_domain": true }]
+      "preview_urls": true,
+      "routes": [{ "pattern": "dev.bayanflow.com", "custom_domain": true }]
     },
     "production": {
       "name": "bayan-flow",
       "workers_dev": true,
-      "preview_urls": true
-      // "routes": [{ "pattern": "bayanflow.com", "custom_domain": true }]
+      "preview_urls": true,
+      "routes": [
+        { "pattern": "bayanflow.com", "custom_domain": true },
+        { "pattern": "www.bayanflow.com", "custom_domain": true }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Contribution workflow

- [x] **Base branch is `main`:** This PR targets **`main`** from **`develop`**.
- [x] **Guidelines and docs:** Read CONTRIBUTING.md and relevant docs.
- [x] **This template:** PR template structure kept; sections below filled in.

## Description

Final migration merge: ships the **production custom-domain routes** in `wrangler.jsonc` to `main` so the **bayan-flow** worker deploys with `bayanflow.com` and `www.bayanflow.com`.

**This is not a v0.5.0 release PR.** It completes the Netlify → Cloudflare cutover on the production branch. Staging (`dev.bayanflow.com`) should already be on Cloudflare from the prior `develop` deploy.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI improvement
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or improvement
- [x] 🔧 Chore (maintenance, dependencies, etc.)

## Related Issues

Fixes #

## Changes Made

### Migration (why this PR exists)

- Production `routes` in `wrangler.jsonc`: `bayanflow.com`, `www.bayanflow.com`
- Triggers **Deploy (Cloudflare Workers)** on `main` with `--env production`

### Also on `develop` (rides along with merge)

Everything already merged to `develop` since the last `main` sync — including staging custom domain config, Cloudflare hosting (#183), and ongoing v0.5.0 work. No separate release tag planned.

## Algorithm Details (if applicable)

N/A

## Testing

- [x] `workers.dev` production + staging smoke-tested
- [x] `dev.bayanflow.com` verified on Cloudflare (staging) after prior `develop` merge
- [ ] After this merge: **Deploy (Cloudflare Workers)** green on `main`
- [ ] **bayan-flow** → Domains → `bayanflow.com` + `www.bayanflow.com` active
- [ ] DNS updated for apex + www (remove stale Netlify records if needed)
- [ ] Smoke https://bayanflow.com and https://www.bayanflow.com

### Test Results

Rely on CI + post-merge deploy success and live URL checks.

## Screenshots/GIFs

N/A

## Code Quality

- [x] `develop` CI green
- [x] Merge-only; no new commits expected on this PR

## Performance Impact

- [x] No performance impact

## Accessibility

- [x] N/A

## Breaking Changes

- **Production DNS cutover** is manual after deploy. `bayanflow.com` may still resolve to Netlify until DNS records are updated.
- Netlify projects retained ~2 weeks as rollback.

## Checklist

- [x] Staging custom domain live on Cloudflare
- [ ] Merge this PR → production worker deploy succeeds
- [ ] Confirm domains on **bayan-flow** worker
- [ ] DNS cutover for `bayanflow.com` / `www`
- [ ] Production smoke test (SPA refresh, badge, locales)
- [ ] Keep Netlify as rollback ~2 weeks, then cleanup

## Additional Notes

### After merge

1. **Actions** → **Deploy (Cloudflare Workers)** on `main` → green
2. **bayan-flow** → **Domains** → confirm `bayanflow.com`, `www.bayanflow.com`
3. **DNS** (zone on Cloudflare): remove/replace Netlify CNAMEs if traffic still hits Netlify
4. Smoke production URLs (same checklist as `workers.dev` + legal pages)

### Migration complete when

- [ ] `dev.bayanflow.com` → Cloudflare staging worker  
- [ ] `bayanflow.com` / `www` → Cloudflare production worker  
- [ ] Both stable ~2 weeks → delete Netlify Bayan Flow projects  

Then: Supabase auth (next phase).

### Rollback

Point DNS back to Netlify. Projects and `netlify.toml` still available.

---

**Reviewer Guidelines:**
- Treat as migration merge, not feature review
- Confirm production deploy workflow will run on `main`
