### PR TITLE
ci: add workflow to keep Supabase free-tier project alive

### DIFF
--- a/.github/workflows/keep-supabase-alive.yml
+++ b/.github/workflows/keep-supabase-alive.yml
@@ -11,6 +11,6 @@ jobs:
     steps:
       - name: Ping Supabase REST API
         run: |
-          curl -sf "${{ secrets.VITE_SUPABASE_URL }}/rest/v1/profiles?select=id&limit=1" \
+          curl -sf "${{ secrets.VITE_SUPABASE_URL }}/rest/v1/keepalive?select=id&limit=1" \
             -H "apikey: ${{ secrets.VITE_SUPABASE_ANON_KEY }}" \
             -H "Authorization: Bearer ${{ secrets.VITE_SUPABASE_ANON_KEY }}"

--- a/.github/workflows/keep-supabase-alive.yml
+++ b/.github/workflows/keep-supabase-alive.yml
@@ -1,0 +1,16 @@
+name: Keep Supabase Alive
+
+on:
+  schedule:
+    - cron: "0 0 */3 * *"
+  workflow_dispatch:
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping Supabase REST API
+        run: |
+          curl -sf "${{ secrets.VITE_SUPABASE_URL }}/rest/v1/profiles?select=id&limit=1" \
+            -H "apikey: ${{ secrets.VITE_SUPABASE_ANON_KEY }}" \
+            -H "Authorization: Bearer ${{ secrets.VITE_SUPABASE_ANON_KEY }}"


### PR DESCRIPTION
## Contribution workflow

- [x] **Base branch is `develop`:** This PR targets **`develop`**, not `main`.
- [x] **Guidelines and docs:** I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and the docs relevant to my change.
- [x] **This template:** I kept the PR template structure and filled in the sections below.

## Description

Add a scheduled GitHub Actions workflow that prevents the Supabase free-tier project from auto-pausing due to 7 consecutive days of inactivity. The workflow sends a read-only request to the Supabase REST API every 3 days, resetting the inactivity clock indefinitely with zero manual maintenance.

## Type of Change

- [x] 🔧 Chore (maintenance, dependencies, etc.)

## Related Issues

N/A

## Changes Made

- Created `.github/workflows/keep-supabase-alive.yml` with:
  - Cron schedule: every 3 days at UTC midnight (`0 0 */3 * *`)
  - Manual trigger via `workflow_dispatch`
  - Single `curl` step hitting `/rest/v1/profiles?select=id&limit=1` with the anon key
  - Uses existing repo secrets `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` — no new secrets created
  - No service role key, no writes, no new tables — read-only and least-privilege by design

## Testing

- [x] All existing tests pass (`pnpm test:run`) — 1656 passed, 2 pre-existing failures in `pyodideCdn.test.js` (env import ordering, unrelated)
- [x] ESLint passes (`pnpm lint`) — 0 errors, 1 pre-existing warning
- [x] Prettier formatting applied (`pnpm format:check`) — all files clean
- [x] Workflow YAML validated

## Code Quality

- [x] Code follows the project's coding standards
- [x] ESLint passes (`pnpm lint`)
- [x] Prettier formatting applied (`pnpm format`)
- [x] No console errors or warnings

## Performance Impact

- [x] No performance impact

## Breaking Changes

- None

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

- The 3-day interval provides a 4-day buffer before the 7-day pause threshold, so even if a scheduled run is missed by GitHub Actions, the project stays active.
- No Telegram failure notifications are included because `TELEGRAM_BOT_TOKEN` / `TELEGRAM_CHAT_ID` secrets do not exist in this repo.
- The `-f` flag on `curl` causes the step to fail on non-2xx responses, so broken pings show red in the Actions tab.
- After merging, trigger the workflow manually once from the Actions tab to verify the secrets resolve correctly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a scheduled “Keep Supabase Alive” automation that periodically sends a lightweight request to Supabase to help keep the service responsive.
  * The same workflow can also be triggered manually when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->