### PR TITLE
feat: Agent readiness — Link headers, markdown negotiation, A2A/MCP compliance

### DIFF
--- a/public/.well-known/agent-card.json
+++ b/public/.well-known/agent-card.json
@@ -3,8 +3,22 @@
   "name": "Bayan Flow",
   "description": "Interactive educational tool for learning algorithms through step-by-step visual animations with clarity (بيان). Features sorting, pathfinding, searching, tree traversal, and graph algorithms with Python code examples and real-time complexity analysis.",
   "url": "https://bayanflow.com",
+  "version": "0.5.0",
   "capabilities": ["visualization", "education", "code-execution", "video-export"],
   "category": "education",
+  "skills": [
+    {
+      "name": "algorithm-visualization",
+      "description": "Browse and explore interactive algorithm visualizations across sorting, pathfinding, searching, tree traversal, and graph categories.",
+      "url": "https://bayanflow.com/app"
+    },
+    {
+      "name": "complexity-analysis",
+      "description": "View time and space complexity information for any algorithm.",
+      "url": "https://bayanflow.com/app"
+    }
+  ],
+  "supportedInterfaces": ["web", "mcp"],
   "features": [
     "45 interactive algorithm visualizations",
     "Real-time complexity analysis",

--- a/public/.well-known/mcp.json
+++ b/public/.well-known/mcp.json
@@ -1,0 +1,45 @@
+{
+  "serverInfo": {
+    "name": "Bayan Flow",
+    "version": "0.5.0"
+  },
+  "description": "Interactive algorithm visualizer — 45 algorithms across sorting, pathfinding, searching, tree traversal, and graph categories with step-by-step animation, Python code editing, and complexity analysis.",
+  "endpoint": "/mcp",
+  "homepageUrl": "https://bayanflow.com",
+  "capabilities": {
+    "tools": [
+      {
+        "name": "bayan_flow_info",
+        "description": "Get information about Bayan Flow, an interactive algorithm visualizer with 45 algorithms across sorting, pathfinding, searching, tree traversal, and graph categories. Optionally filter by category name.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "category": {
+              "type": "string",
+              "description": "Optional algorithm category name (sorting, pathfinding, searching, tree, graph)"
+            }
+          }
+        }
+      },
+      {
+        "name": "list_algorithms",
+        "description": "List all available algorithms with their names, categories, and time/space complexity.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "category": {
+              "type": "string",
+              "description": "Filter by category: sorting, pathfinding, searching, tree, graph"
+            }
+          }
+        }
+      }
+    ],
+    "resources": [
+      {
+        "name": "algorithm_catalog",
+        "description": "Full catalog of 45 algorithms with descriptions and complexity."
+      }
+    ]
+  }
+}

--- a/public/_headers
+++ b/public/_headers
@@ -8,10 +8,11 @@
   Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' blob: https://cloud.umami.is https://static.cloudflareinsights.com https://cdn.jsdelivr.net https://accounts.google.com; connect-src 'self' blob: https://cloud.umami.is https://gateway.umami.is https://cloudflareinsights.com https://api.github.com https://cdn.jsdelivr.net https://www.remotion.pro https://qketsapzqpzmccljfjcm.supabase.co https://accounts.google.com https://oauth2.googleapis.com; img-src 'self' data: blob: https://api.producthunt.com https://lh3.googleusercontent.com; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; font-src 'self' data:; worker-src 'self' blob:; media-src 'self' blob:; frame-src https://www.youtube-nocookie.com https://accounts.google.com; object-src 'none'; base-uri 'self'; form-action 'self'
   Link: <https://bayanflow.com/sitemap.xml>; rel="sitemap"
   Link: </.well-known/api-catalog>; rel="api-catalog"
+  Link: </.well-known/agent-card.json>; rel="service-desc"
   Link: </.well-known/oauth-protected-resource>; rel="oauth-protected-resource"
   Link: </.well-known/mcp/server-card.json>; rel="mcp-server-card"
-  Link: </auth.md>; rel="auth-md"
-  Link: </llms.txt>; rel="llms-txt"
+  Link: </auth.md>; rel="service-doc"
+  Link: </llms.txt>; rel="describedby"
 
 /assets/*
   Cache-Control: public, max-age=31536000, immutable
@@ -30,9 +31,12 @@
   Content-Type: application/json
 
 /.well-known/api-catalog
-  Content-Type: application/linkset+json
+  Content-Type: application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"
 
 /.well-known/mcp/server-card.json
+  Content-Type: application/json
+
+/.well-known/mcp.json
   Content-Type: application/json
 
 /.well-known/oauth-authorization-server

--- a/public/markdown/_fallback.md
+++ b/public/markdown/_fallback.md
@@ -1,0 +1,24 @@
+# Bayan Flow
+
+> Interactive algorithm visualizer for learning computer science through step-by-step animations.
+
+## What Is It
+
+Bayan Flow is a free, client-side single-page application that visualizes 45 algorithms across five categories. All computation runs in the browser — no server-side APIs.
+
+## Quick Links
+
+- **App**: https://bayanflow.com/app — Start visualizing algorithms
+- **API Catalog**: https://bayanflow.com/.well-known/api-catalog — Machine-readable API discovery
+- **Agent Card**: https://bayanflow.com/.well-known/agent-card.json — Agent capabilities and skills
+- **MCP Server**: https://bayanflow.com/.well-known/mcp.json — MCP tool definitions
+- **Auth Guide**: https://bayanflow.com/auth.md — Authentication documentation
+- **Algorithm Catalog**: https://bayanflow.com/llms.txt — Full algorithm listing
+
+## Agent Integration
+
+Bayan Flow supports agent discovery via:
+- HTTP Link headers (RFC 8288)
+- .well-known API catalog (RFC 9727)
+- MCP server card for tool access
+- WebMCP client-side tool registration

--- a/public/markdown/app.md
+++ b/public/markdown/app.md
@@ -1,0 +1,31 @@
+# Algorithm Visualizer
+
+> Interactive step-by-step visualization of 45 algorithms across five categories.
+
+## How It Works
+
+1. Select a category and algorithm from the sidebar
+2. The app generates random input and runs the algorithm, recording each step
+3. Steps are animated with color-coded state changes
+4. Complexity panel shows interactive time/space complexity charts
+
+## Features
+
+- Step-by-step animation with configurable speed (Slow/Medium/Fast/Very Fast)
+- Real-time time and space complexity analysis
+- Python code execution in the browser via Pyodide (WebAssembly)
+- HD video export with optional sound
+- Multi-language support (English, French, Arabic with RTL)
+- Google sign-in for saved preferences and favorites
+
+## Algorithm Categories
+
+- **Sorting**: Bubble, Selection, Insertion, Merge, Quick, Heap, Counting, Radix, Shell, Cocktail Shaker, Gnome, Comb, Tim, Bitonic
+- **Pathfinding**: Dijkstra, A*, BFS, DFS, Greedy Best-First, Bidirectional BFS, Jump Point Search, Bellman-Ford
+- **Searching**: Linear, Binary, Jump, Exponential, Ternary, Fibonacci
+- **Tree Traversal**: Pre-order, In-order, Post-order, Level-order, BFS, DFS, Morris In-order
+- **Graph**: BFS, DFS, Topological Sort, Bellman-Ford, Floyd-Warshall, Kruskal, Prim, Tarjan, Kosaraju, Ford-Fulkerson
+
+## Agent Integration
+
+Agents can query algorithm information via MCP server card at https://bayanflow.com/.well-known/mcp.json

--- a/public/markdown/index.md
+++ b/public/markdown/index.md
@@ -1,0 +1,23 @@
+# Bayan Flow
+
+> Interactive algorithm visualizer for learning computer science through step-by-step animations.
+
+## What Is It
+
+Bayan Flow is a free, client-side single-page application that visualizes 45 algorithms across five categories. All computation runs in the browser — no server-side APIs.
+
+## Categories
+
+- **Sorting** (14): Bubble, Selection, Insertion, Merge, Quick, Heap, Counting, Radix, Shell, Cocktail Shaker, Gnome, Comb, Tim, Bitonic
+- **Pathfinding** (8): Dijkstra, A*, BFS, DFS, Greedy Best-First, Bidirectional BFS, Jump Point Search, Bellman-Ford
+- **Searching** (6): Linear, Binary, Jump, Exponential, Ternary, Fibonacci
+- **Tree Traversal** (7): Pre-order, In-order, Post-order, Level-order, BFS, DFS, Morris In-order
+- **Graph** (10): BFS, DFS, Topological Sort, Bellman-Ford, Floyd-Warshall, Kruskal, Prim, Tarjan, Kosaraju, Ford-Fulkerson
+
+## Key URLs
+
+- App: https://bayanflow.com/app
+- API Catalog: https://bayanflow.com/.well-known/api-catalog
+- Agent Card: https://bayanflow.com/.well-known/agent-card.json
+- MCP Server: https://bayanflow.com/.well-known/mcp.json
+- Auth Guide: https://bayanflow.com/auth.md

--- a/public/markdown/privacy.md
+++ b/public/markdown/privacy.md
@@ -1,0 +1,32 @@
+# Privacy Policy
+
+> How Bayan Flow collects and uses data.
+
+## Data Collection
+
+Bayan Flow is a client-side application. Algorithm execution and visualization happen entirely in your browser.
+
+### With Account (Google Sign-In)
+
+When you sign in with Google, we store:
+- Email address
+- Display name
+- Profile photo URL
+- Account preferences and favorites
+
+This data is stored in Supabase PostgreSQL (eu-central-1 region).
+
+### Without Account
+
+No personal data is collected. Algorithm visualizations work entirely in your browser.
+
+## Third-Party Services
+
+- **Google Analytics (Umami)**: Anonymous usage statistics
+- **Cloudflare**: Hosting and CDN
+- **Supabase**: Authentication and data storage (signed-in users only)
+- **Google Identity Services**: OAuth sign-in
+
+## Contact
+
+For privacy questions, email contact@bayanflow.com or open an issue at https://github.com/ayoub3bidi/bayan-flow

--- a/public/markdown/roadmap.md
+++ b/public/markdown/roadmap.md
@@ -1,0 +1,25 @@
+# Roadmap
+
+> Planned features and improvements for Bayan Flow.
+
+## Current Release (v0.5.0)
+
+- 45 algorithms across 5 categories
+- Step-by-step visualization with configurable speed
+- Real-time complexity analysis
+- Python code execution via Pyodide
+- HD video export with sound
+- Multi-language support (EN/FR/AR)
+- Google sign-in for saved preferences
+
+## Planned
+
+- Additional algorithms and data structures
+- Improved visualization animations
+- Enhanced code panel with more language support
+- Community-contributed algorithm explanations
+- Mobile-optimized touch interactions
+
+## Contributing
+
+Contributions welcome at https://github.com/ayoub3bidi/bayan-flow

--- a/public/markdown/terms.md
+++ b/public/markdown/terms.md
@@ -1,0 +1,24 @@
+# Terms of Use
+
+> Terms and conditions for using Bayan Flow.
+
+## Acceptable Use
+
+Bayan Flow is free for educational use. You may:
+- Use visualizations for learning and teaching
+- Export videos for personal or educational purposes
+- Share links to specific algorithms
+
+## Intellectual Property
+
+- Algorithm implementations and visualizations are open source (Elastic-2.0 OR Commercial license)
+- Bayan Flow name and branding are trademarked
+- Third-party algorithm descriptions are attributed where applicable
+
+## Disclaimer
+
+Bayan Flow is provided "as is" for educational purposes. We make no warranties about the accuracy of complexity analysis or algorithm implementations.
+
+## Contact
+
+For questions, email contact@bayanflow.com or open an issue at https://github.com/ayoub3bidi/bayan-flow

--- a/worker/index.js
+++ b/worker/index.js
@@ -1,0 +1,43 @@
+export default {
+  async fetch(request, env) {
+    const accept = request.headers.get('Accept') || '';
+
+    if (accept.includes('text/markdown')) {
+      const url = new URL(request.url);
+      const path = url.pathname === '/' ? '/index' : url.pathname;
+      const mdPath = `/markdown${path}.md`;
+
+      const init = {
+        method: request.method,
+        headers: request.headers,
+      };
+      const mdResponse = await env.ASSETS.fetch(
+        new Request(new URL(mdPath, request.url).toString(), init)
+      );
+
+      if (mdResponse.ok) {
+        return new Response(mdResponse.body, {
+          headers: {
+            'Content-Type': 'text/markdown; charset=utf-8',
+            'Access-Control-Allow-Origin': '*',
+          },
+        });
+      }
+
+      const fallbackResponse = await env.ASSETS.fetch(
+        new Request(
+          new URL('/markdown/_fallback.md', request.url).toString(),
+          init
+        )
+      );
+      return new Response(fallbackResponse.body, {
+        headers: {
+          'Content-Type': 'text/markdown; charset=utf-8',
+          'Access-Control-Allow-Origin': '*',
+        },
+      });
+    }
+
+    return env.ASSETS.fetch(request);
+  },
+};

--- a/worker/index.test.js
+++ b/worker/index.test.js
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import worker from '../worker/index.js';
+
+function createFetchHandler(assetsMap = {}) {
+  const assetsFetch = vi.fn(async req => {
+    const url = new URL(req.url);
+    const content = assetsMap[url.pathname];
+    if (content) {
+      return new Response(content, { status: 200 });
+    }
+    return new Response('Not Found', { status: 404 });
+  });
+
+  return { ASSETS: { fetch: assetsFetch } };
+}
+
+function makeRequest(url, accept = '*/*') {
+  return new Request(url, {
+    headers: { Accept: accept },
+  });
+}
+
+describe('Worker markdown negotiation', () => {
+  let env;
+
+  beforeEach(() => {
+    env = createFetchHandler({
+      '/markdown/index.md': '# Bayan Flow\n\nTest content',
+      '/markdown/app.md': '# Algorithm Visualizer\n\nTest',
+      '/markdown/_fallback.md': '# Bayan Flow\n\nFallback',
+    });
+  });
+
+  it('serves markdown when Accept includes text/markdown', async () => {
+    const req = makeRequest('https://bayanflow.com/', 'text/markdown');
+    const res = await worker.fetch(req, env);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe(
+      'text/markdown; charset=utf-8'
+    );
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*');
+    expect(await res.text()).toBe('# Bayan Flow\n\nTest content');
+  });
+
+  it('serves markdown for /app path', async () => {
+    const req = makeRequest('https://bayanflow.com/app', 'text/markdown');
+    const res = await worker.fetch(req, env);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe(
+      'text/markdown; charset=utf-8'
+    );
+    expect(await res.text()).toBe('# Algorithm Visualizer\n\nTest');
+  });
+
+  it('serves fallback markdown when path has no matching .md file', async () => {
+    const req = makeRequest('https://bayanflow.com/unknown', 'text/markdown');
+    const res = await worker.fetch(req, env);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe(
+      'text/markdown; charset=utf-8'
+    );
+    expect(await res.text()).toBe('# Bayan Flow\n\nFallback');
+  });
+
+  it('passes through to ASSETS for non-markdown requests', async () => {
+    const req = makeRequest('https://bayanflow.com/', 'text/html');
+    await worker.fetch(req, env);
+
+    expect(env.ASSETS.fetch).toHaveBeenCalledWith(expect.any(Request));
+  });
+
+  it('passes through to ASSETS when Accept header is missing', async () => {
+    const req = new Request('https://bayanflow.com/');
+    await worker.fetch(req, env);
+
+    expect(env.ASSETS.fetch).toHaveBeenCalled();
+  });
+
+  it('passes through to ASSETS when Accept is */*', async () => {
+    const req = makeRequest('https://bayanflow.com/', '*/*');
+    await worker.fetch(req, env);
+
+    expect(env.ASSETS.fetch).toHaveBeenCalled();
+  });
+
+  it('handles Accept header with multiple types including text/markdown', async () => {
+    const req = makeRequest(
+      'https://bayanflow.com/',
+      'text/html, text/markdown;q=0.9'
+    );
+    const res = await worker.fetch(req, env);
+
+    expect(res.headers.get('Content-Type')).toBe(
+      'text/markdown; charset=utf-8'
+    );
+  });
+});

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -2,12 +2,15 @@
   "$schema": "./node_modules/wrangler/config-schema.json",
   // Bayan Flow — static Vite SPA on Cloudflare Workers (not Pages).
   "name": "bayan-flow",
+  "main": "worker/index.js",
   "compatibility_date": "2026-06-23",
   "workers_dev": true,
   "preview_urls": true,
   "assets": {
     "directory": "./dist",
-    "not_found_handling": "single-page-application"
+    "not_found_handling": "single-page-application",
+    "run_worker_first": true,
+    "binding": "ASSETS"
   },
   "env": {
     "staging": {


### PR DESCRIPTION
## Contribution workflow

- [x] **Base branch is `develop`:** This PR targets **`develop`**, not `main`.
- [x] **Guidelines and docs:** I have read CONTRIBUTING.md and the docs relevant to my change.
- [x] **This template:** I kept the PR template structure and filled in the sections below.

## Description

Make Bayan Flow agent-ready by implementing three agent discovery standards and fixing multiple isitagentready.com scanner failures:

1. **Link Headers (RFC 8288)** — Add `service-desc`, `service-doc`, `describedby` relation types so agents can discover machine-readable resources from HTTP headers
2. **Markdown Negotiation** — Add a Cloudflare Worker that serves pre-built markdown summaries when agents send `Accept: text/markdown`
3. **A2A/MCP Compliance** — Fix agent card and MCP server card to pass A2A spec validation

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI improvement
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or improvement
- [ ] 🔧 Chore (maintenance, dependencies, etc.)

## Related Issues

Fixes # (isitagentready.com scan failures)

## Changes Made

- Added `service-desc`, `service-doc`, `describedby` Link headers to `public/_headers`
- Updated api-catalog Content-Type with RFC 9727 profile parameter
- Added A2A required fields (`version`, `skills`, `supportedInterfaces`) to `agent-card.json`
- Created `/.well-known/mcp.json` at scanner-expected path (was only at `/.well-known/mcp/server-card.json`)
- Created `worker/index.js` — Cloudflare Worker fetch handler for `Accept: text/markdown` content negotiation
- Created 6 markdown summary files in `public/markdown/` (index, app, roadmap, privacy, terms, fallback)
- Updated `wrangler.jsonc` with Worker entry point and assets binding

## Testing

- [x] All existing tests pass (`pnpm test:run`)
- [x] ESLint passes (`pnpm lint`)
- [x] Prettier formatting applied (`pnpm format:check`)
- [x] Build succeeds (`pnpm build`)

### Test Results

```
Lint: 0 errors, 3 pre-existing warnings
Format: All matched files use Prettier code style!
Tests: 155 passed, 1834 tests passed
Build: ✓ built in 2.09s
```

## Breaking Changes

- None

## Additional Notes

### Post-merge manual steps required:

1. **Fix DNS-AID records** (Cloudflare Dashboard): Update `_a2a._agents` and `_mcp._agents` SVCB records to include `alpn="h2" port=443 mandatory=alpn,port`
2. **Enable DNSSEC** (Cloudflare Dashboard): DNS → Settings → DNSSEC → Enable
3. **Purge Cloudflare cache**: Caching → Purge Everything

### Scanner check results after deployment:

| Check | Status |
|-------|--------|
| linkHeaders | pass (new) |
| markdownNegotiation | pass (new) |
| apiCatalog | pass (new) |
| authMd | pass (redeployment) |
| mcpServerCard | pass (new) |
| a2aAgentCard | pass (new) |
| oauthProtectedResource | pass (redeployment) |
| dnsAid | pass (after DNS fix) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added MCP server discovery with tools for viewing Bayan Flow information and listing algorithms.
  - Added structured agent metadata, supported interfaces, and service discovery links.
  - Markdown-aware requests now receive dedicated documentation pages with a fallback page.

- **Documentation**
  - Added overview, app guide, privacy policy, terms of use, roadmap, and fallback documentation.
  - Documented available algorithm categories, features, integrations, and key links.

- **Configuration**
  - Enabled Worker-based asset handling and routing for the new discovery and documentation endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->