### PR TITLE
fix: address all CodeRabbit review comments from PR #210

### DIFF
--- a/src/components/ArrayVisualizer.jsx
+++ b/src/components/ArrayVisualizer.jsx
@@ -187,10 +187,12 @@ function ArrayVisualizer({
                 role="button"
                 tabIndex={0}
                 onClick={() => onGatedFeatureClick?.('complexity_limit')}
-                onKeyDown={e =>
-                  (e.key === 'Enter' || e.key === ' ') &&
-                  onGatedFeatureClick?.('complexity_limit')
-                }
+                onKeyDown={e => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    onGatedFeatureClick?.('complexity_limit');
+                  }
+                }}
               >
                 <div className="text-center text-white p-6 max-w-xs">
                   <p className="text-lg font-semibold mb-2">

--- a/src/components/ArrayVisualizer.jsx
+++ b/src/components/ArrayVisualizer.jsx
@@ -183,9 +183,24 @@ function ArrayVisualizer({
               <motion.div
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}
-                className="absolute inset-0 bg-black/30 z-10"
-                aria-hidden="true"
-              />
+                className="absolute inset-0 z-10 flex items-center justify-center bg-black/80"
+                role="button"
+                tabIndex={0}
+                onClick={() => onGatedFeatureClick?.('complexity_limit')}
+                onKeyDown={e =>
+                  (e.key === 'Enter' || e.key === ' ') &&
+                  onGatedFeatureClick?.('complexity_limit')
+                }
+              >
+                <div className="text-center text-white p-6 max-w-xs">
+                  <p className="text-lg font-semibold mb-2">
+                    {t('featureGate.complexity_limit')}
+                  </p>
+                  <p className="text-sm opacity-80">
+                    {t('featureGate.complexity_limit_description')}
+                  </p>
+                </div>
+              </motion.div>
             )}
           </div>
         ) : (

--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -4,13 +4,8 @@
  * See LICENSE for details.
  */
 
-import { Component } from 'react';
+import { Component, createElement } from 'react';
 
-/**
- * React error boundary that catches render errors in its subtree
- * and displays a non-destructive fallback instead of crashing the
- * entire application.
- */
 class ErrorBoundary extends Component {
   constructor(props) {
     super(props);
@@ -25,9 +20,38 @@ class ErrorBoundary extends Component {
     console.error('[ErrorBoundary]', error, info?.componentStack);
   }
 
+  componentDidUpdate(prevProps) {
+    if (prevProps.resetKey !== this.props.resetKey && this.state.hasError) {
+      this.setState({ hasError: false });
+    }
+  }
+
   render() {
     if (this.state.hasError) {
-      return this.props.fallback ?? null;
+      return (
+        this.props.fallback ??
+        createElement(
+          'div',
+          {
+            className:
+              'flex flex-col items-center justify-center h-full p-8 text-center',
+          },
+          createElement(
+            'p',
+            { className: 'text-lg font-semibold mb-2' },
+            'Something went wrong.'
+          ),
+          createElement(
+            'button',
+            {
+              className:
+                'mt-2 px-4 py-2 rounded-lg bg-blue-600 text-white hover:bg-blue-700',
+              onClick: () => this.setState({ hasError: false }),
+            },
+            'Try again'
+          )
+        )
+      );
     }
     return this.props.children;
   }

--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -44,6 +44,7 @@ class ErrorBoundary extends Component {
           createElement(
             'button',
             {
+              type: 'button',
               className:
                 'mt-2 px-4 py-2 rounded-lg bg-blue-600 text-white hover:bg-blue-700',
               onClick: () => this.setState({ hasError: false }),

--- a/src/components/ErrorBoundary.test.jsx
+++ b/src/components/ErrorBoundary.test.jsx
@@ -33,14 +33,35 @@ describe('ErrorBoundary', () => {
     spy.mockRestore();
   });
 
-  it('renders nothing when a child throws and no fallback provided', () => {
+  it('renders built-in fallback when a child throws and no fallback provided', () => {
     const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    const { container } = render(
+    render(
       <ErrorBoundary>
         <Boom />
       </ErrorBoundary>
     );
-    expect(container.innerHTML).toBe('');
+    expect(screen.getByText('Something went wrong.')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Try again' })
+    ).toBeInTheDocument();
+    spy.mockRestore();
+  });
+
+  it('recovers when resetKey changes', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { rerender } = render(
+      <ErrorBoundary resetKey={1}>
+        <Boom />
+      </ErrorBoundary>
+    );
+    expect(screen.getByText('Something went wrong.')).toBeInTheDocument();
+
+    rerender(
+      <ErrorBoundary resetKey={2}>
+        <span>recovered content</span>
+      </ErrorBoundary>
+    );
+    expect(screen.getByText('recovered content')).toBeInTheDocument();
     spy.mockRestore();
   });
 });

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -181,7 +181,7 @@ function Footer() {
             </p>
             <div className="flex items-center gap-2">
               <a
-                href="https://github.com/ayoub3bidi/bayan-flow/blob/develop/LICENSE"
+                href={`${GITHUB_REPO_URL}/blob/main/LICENSE`}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-orange-100 text-orange-800 border border-orange-200 hover:bg-orange-200 transition-colors"

--- a/src/components/GraphAlgorithmMatrixVisualizer.jsx
+++ b/src/components/GraphAlgorithmMatrixVisualizer.jsx
@@ -103,9 +103,24 @@ function GraphAlgorithmMatrixVisualizer({
           <motion.div
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
-            className="absolute inset-0 bg-black/30 z-10"
-            aria-hidden="true"
-          />
+            className="absolute inset-0 z-10 flex items-center justify-center bg-black/80"
+            role="button"
+            tabIndex={0}
+            onClick={() => onGatedFeatureClick?.('complexity_limit')}
+            onKeyDown={e =>
+              (e.key === 'Enter' || e.key === ' ') &&
+              onGatedFeatureClick?.('complexity_limit')
+            }
+          >
+            <div className="text-center text-white p-6 max-w-xs">
+              <p className="text-lg font-semibold mb-2">
+                {t('featureGate.complexity_limit')}
+              </p>
+              <p className="text-sm opacity-80">
+                {t('featureGate.complexity_limit_description')}
+              </p>
+            </div>
+          </motion.div>
         )}
       </div>
     );

--- a/src/components/GraphAlgorithmMatrixVisualizer.jsx
+++ b/src/components/GraphAlgorithmMatrixVisualizer.jsx
@@ -107,10 +107,12 @@ function GraphAlgorithmMatrixVisualizer({
             role="button"
             tabIndex={0}
             onClick={() => onGatedFeatureClick?.('complexity_limit')}
-            onKeyDown={e =>
-              (e.key === 'Enter' || e.key === ' ') &&
-              onGatedFeatureClick?.('complexity_limit')
-            }
+            onKeyDown={e => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                onGatedFeatureClick?.('complexity_limit');
+              }
+            }}
           >
             <div className="text-center text-white p-6 max-w-xs">
               <p className="text-lg font-semibold mb-2">

--- a/src/components/GraphAlgorithmMatrixVisualizer.test.jsx
+++ b/src/components/GraphAlgorithmMatrixVisualizer.test.jsx
@@ -120,9 +120,11 @@ describe('GraphAlgorithmMatrixVisualizer', () => {
         vi.advanceTimersByTime(1000);
       });
 
-      const blurOverlay = document.querySelector('.bg-black\\/30');
+      const blurOverlay = document.querySelector('.bg-black\\/80');
       expect(blurOverlay).toBeInTheDocument();
-      expect(screen.getByText('Complexity Analysis')).toBeInTheDocument();
+      expect(
+        screen.getAllByText('Complexity Analysis').length
+      ).toBeGreaterThanOrEqual(1);
     } finally {
       vi.useRealTimers();
     }

--- a/src/components/GraphVisualizer.jsx
+++ b/src/components/GraphVisualizer.jsx
@@ -325,10 +325,12 @@ function GraphVisualizer({
                 role="button"
                 tabIndex={0}
                 onClick={() => onGatedFeatureClick?.('complexity_limit')}
-                onKeyDown={e =>
-                  (e.key === 'Enter' || e.key === ' ') &&
-                  onGatedFeatureClick?.('complexity_limit')
-                }
+                onKeyDown={e => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    onGatedFeatureClick?.('complexity_limit');
+                  }
+                }}
               >
                 <div className="text-center text-white p-6 max-w-xs">
                   <p className="text-lg font-semibold mb-2">

--- a/src/components/GraphVisualizer.jsx
+++ b/src/components/GraphVisualizer.jsx
@@ -321,9 +321,24 @@ function GraphVisualizer({
               <motion.div
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}
-                className="absolute inset-0 bg-black/30 z-10"
-                aria-hidden="true"
-              />
+                className="absolute inset-0 z-10 flex items-center justify-center bg-black/80"
+                role="button"
+                tabIndex={0}
+                onClick={() => onGatedFeatureClick?.('complexity_limit')}
+                onKeyDown={e =>
+                  (e.key === 'Enter' || e.key === ' ') &&
+                  onGatedFeatureClick?.('complexity_limit')
+                }
+              >
+                <div className="text-center text-white p-6 max-w-xs">
+                  <p className="text-lg font-semibold mb-2">
+                    {t('featureGate.complexity_limit')}
+                  </p>
+                  <p className="text-sm opacity-80">
+                    {t('featureGate.complexity_limit_description')}
+                  </p>
+                </div>
+              </motion.div>
             )}
           </div>
         ) : (

--- a/src/components/GraphVisualizer.test.jsx
+++ b/src/components/GraphVisualizer.test.jsx
@@ -195,9 +195,11 @@ describe('GraphVisualizer', () => {
         vi.advanceTimersByTime(1000);
       });
 
-      const blurOverlay = document.querySelector('.bg-black\\/30');
+      const blurOverlay = document.querySelector('.bg-black\\/80');
       expect(blurOverlay).toBeInTheDocument();
-      expect(screen.getByText('Complexity Analysis')).toBeInTheDocument();
+      expect(
+        screen.getAllByText('Complexity Analysis').length
+      ).toBeGreaterThanOrEqual(1);
     } finally {
       vi.useRealTimers();
     }

--- a/src/components/GridVisualizer.jsx
+++ b/src/components/GridVisualizer.jsx
@@ -186,10 +186,12 @@ function GridVisualizer({
                 role="button"
                 tabIndex={0}
                 onClick={() => onGatedFeatureClick?.('complexity_limit')}
-                onKeyDown={e =>
-                  (e.key === 'Enter' || e.key === ' ') &&
-                  onGatedFeatureClick?.('complexity_limit')
-                }
+                onKeyDown={e => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    onGatedFeatureClick?.('complexity_limit');
+                  }
+                }}
               >
                 <div className="text-center text-white p-6 max-w-xs">
                   <p className="text-lg font-semibold mb-2">

--- a/src/components/GridVisualizer.jsx
+++ b/src/components/GridVisualizer.jsx
@@ -182,9 +182,24 @@ function GridVisualizer({
               <motion.div
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}
-                className="absolute inset-0 bg-black/30 z-10"
-                aria-hidden="true"
-              />
+                className="absolute inset-0 z-10 flex items-center justify-center bg-black/80"
+                role="button"
+                tabIndex={0}
+                onClick={() => onGatedFeatureClick?.('complexity_limit')}
+                onKeyDown={e =>
+                  (e.key === 'Enter' || e.key === ' ') &&
+                  onGatedFeatureClick?.('complexity_limit')
+                }
+              >
+                <div className="text-center text-white p-6 max-w-xs">
+                  <p className="text-lg font-semibold mb-2">
+                    {t('featureGate.complexity_limit')}
+                  </p>
+                  <p className="text-sm opacity-80">
+                    {t('featureGate.complexity_limit_description')}
+                  </p>
+                </div>
+              </motion.div>
             )}
           </div>
         ) : (

--- a/src/components/PythonCodePanel.jsx
+++ b/src/components/PythonCodePanel.jsx
@@ -82,16 +82,16 @@ function PythonCodePanel({ isOpen, onClose, algorithm }) {
   // Focus trap
   useEffect(() => {
     if (isOpen && panelRef.current) {
-      const focusableElements = panelRef.current.querySelectorAll(
-        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-      );
-      const firstElement = focusableElements[0];
-      const lastElement = focusableElements[focusableElements.length - 1];
-
       const handleKeyDown = event => {
         if (event.key === 'Escape') {
           onClose();
         } else if (event.key === 'Tab') {
+          const focusableElements = panelRef.current.querySelectorAll(
+            'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+          );
+          const firstElement = focusableElements[0];
+          const lastElement = focusableElements[focusableElements.length - 1];
+
           if (event.shiftKey) {
             if (document.activeElement === firstElement) {
               event.preventDefault();
@@ -107,7 +107,11 @@ function PythonCodePanel({ isOpen, onClose, algorithm }) {
       };
 
       document.addEventListener('keydown', handleKeyDown);
-      firstElement?.focus();
+      panelRef.current
+        .querySelector(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        )
+        ?.focus();
 
       return () => document.removeEventListener('keydown', handleKeyDown);
     }

--- a/src/components/PythonCodePanel.jsx
+++ b/src/components/PythonCodePanel.jsx
@@ -15,6 +15,7 @@ import {
 } from '../algorithms/python';
 import { getPseudocodeForLocale } from '../algorithms/pseudocode';
 import { highlightPseudocodeToHtml } from '../utils/pseudocodeHighlight';
+import { getFocusableElements } from '../utils/focusableElements';
 import Editor from '@monaco-editor/react';
 import { useTheme } from '../hooks/useTheme';
 import { usePythonExecution } from '../hooks/usePythonExecution';
@@ -78,7 +79,6 @@ function PythonCodePanel({ isOpen, onClose, algorithm }) {
     document.addEventListener('keydown', handleEscape);
     return () => document.removeEventListener('keydown', handleEscape);
   }, [isOpen, onClose]);
-
   // Focus trap
   useEffect(() => {
     if (isOpen && panelRef.current) {
@@ -86,9 +86,7 @@ function PythonCodePanel({ isOpen, onClose, algorithm }) {
         if (event.key === 'Escape') {
           onClose();
         } else if (event.key === 'Tab') {
-          const focusableElements = panelRef.current.querySelectorAll(
-            'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-          );
+          const focusableElements = getFocusableElements(panelRef.current);
           const firstElement = focusableElements[0];
           const lastElement = focusableElements[focusableElements.length - 1];
 
@@ -107,16 +105,11 @@ function PythonCodePanel({ isOpen, onClose, algorithm }) {
       };
 
       document.addEventListener('keydown', handleKeyDown);
-      panelRef.current
-        .querySelector(
-          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-        )
-        ?.focus();
+      getFocusableElements(panelRef.current)[0]?.focus();
 
       return () => document.removeEventListener('keydown', handleKeyDown);
     }
   }, [isOpen, onClose]);
-
   const pythonCode = getPythonCode(algorithm);
   const displayName = getAlgorithmDisplayName(algorithm);
   const pseudocodeText = useMemo(

--- a/src/components/SettingsSheet.jsx
+++ b/src/components/SettingsSheet.jsx
@@ -33,6 +33,24 @@ function SettingsSheet({ isOpen, onClose, settingsPanelProps }) {
     const handleKeyDown = event => {
       if (event.key === 'Escape') {
         onClose();
+      } else if (event.key === 'Tab' && panelRef.current) {
+        const focusableElements = panelRef.current.querySelectorAll(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        );
+        const firstElement = focusableElements[0];
+        const lastElement = focusableElements[focusableElements.length - 1];
+
+        if (event.shiftKey) {
+          if (document.activeElement === firstElement) {
+            event.preventDefault();
+            lastElement.focus();
+          }
+        } else {
+          if (document.activeElement === lastElement) {
+            event.preventDefault();
+            firstElement.focus();
+          }
+        }
       }
     };
 

--- a/src/components/SettingsSheet.jsx
+++ b/src/components/SettingsSheet.jsx
@@ -15,6 +15,7 @@ import {
   sheetPanelVariants,
 } from '../motion/chromeMotion';
 import { useBodyScrollLock } from '../hooks/useBodyScrollLock';
+import { getFocusableElements } from '../utils/focusableElements';
 import SettingsPanel from './SettingsPanel';
 
 /**
@@ -26,7 +27,6 @@ function SettingsSheet({ isOpen, onClose, settingsPanelProps }) {
   const panelRef = useRef(null);
 
   useBodyScrollLock(isOpen);
-
   useEffect(() => {
     if (!isOpen) return undefined;
 
@@ -34,9 +34,7 @@ function SettingsSheet({ isOpen, onClose, settingsPanelProps }) {
       if (event.key === 'Escape') {
         onClose();
       } else if (event.key === 'Tab' && panelRef.current) {
-        const focusableElements = panelRef.current.querySelectorAll(
-          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-        );
+        const focusableElements = getFocusableElements(panelRef.current);
         const firstElement = focusableElements[0];
         const lastElement = focusableElements[focusableElements.length - 1];
 

--- a/src/components/ShareExportModal.jsx
+++ b/src/components/ShareExportModal.jsx
@@ -4,7 +4,7 @@
  * See LICENSE for details.
  */
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Share, CopySimple, Check, X } from '@phosphor-icons/react';
 import { SiX } from 'react-icons/si';
@@ -39,9 +39,16 @@ function ShareExportModal({
 }) {
   const { t } = useTranslation();
   const reduceMotion = useReducedMotion();
-  const shareData = generateShareCaption(algorithmName);
+  const shareData = generateShareCaption(algorithmName, t);
   const [caption, setCaption] = useState(shareData.fullShareText);
   const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setCaption(generateShareCaption(algorithmName, t).fullShareText);
+      setCopied(false);
+    }
+  }, [open, algorithmName, t]);
 
   const handleNativeShare = async () => {
     if (!videoBlob) return;

--- a/src/components/ShareExportModal.test.jsx
+++ b/src/components/ShareExportModal.test.jsx
@@ -17,11 +17,25 @@ const mockTranslations = {
   'shareExport.copyCaption': 'Copy caption',
   'shareExport.copied': 'Copied!',
   'shareExport.close': 'Close',
+  'shareExport.captionTemplate':
+    '{{algorithm}}. Step-by-step visualization from Bayan Flow.',
+  'shareExport.titleTemplate': '{{algorithm}} Visualization — Bayan Flow',
+};
+
+const stableT = (key, opts) => {
+  const val = mockTranslations[key] || key;
+  if (opts && typeof val === 'string') {
+    return Object.entries(opts).reduce(
+      (s, [k, v]) => s.replace(new RegExp(`\\{\\{${k}\\}\\}`, 'g'), v),
+      val
+    );
+  }
+  return val;
 };
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: key => mockTranslations[key] || key,
+    t: stableT,
     i18n: { language: 'en' },
   }),
 }));

--- a/src/components/TreeVisualizer.jsx
+++ b/src/components/TreeVisualizer.jsx
@@ -203,9 +203,24 @@ function TreeVisualizer({
               <motion.div
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}
-                className="absolute inset-0 bg-black/30 z-10"
-                aria-hidden="true"
-              />
+                className="absolute inset-0 z-10 flex items-center justify-center bg-black/80"
+                role="button"
+                tabIndex={0}
+                onClick={() => onGatedFeatureClick?.('complexity_limit')}
+                onKeyDown={e =>
+                  (e.key === 'Enter' || e.key === ' ') &&
+                  onGatedFeatureClick?.('complexity_limit')
+                }
+              >
+                <div className="text-center text-white p-6 max-w-xs">
+                  <p className="text-lg font-semibold mb-2">
+                    {t('featureGate.complexity_limit')}
+                  </p>
+                  <p className="text-sm opacity-80">
+                    {t('featureGate.complexity_limit_description')}
+                  </p>
+                </div>
+              </motion.div>
             )}
           </div>
         ) : (

--- a/src/components/TreeVisualizer.jsx
+++ b/src/components/TreeVisualizer.jsx
@@ -207,10 +207,12 @@ function TreeVisualizer({
                 role="button"
                 tabIndex={0}
                 onClick={() => onGatedFeatureClick?.('complexity_limit')}
-                onKeyDown={e =>
-                  (e.key === 'Enter' || e.key === ' ') &&
-                  onGatedFeatureClick?.('complexity_limit')
-                }
+                onKeyDown={e => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    onGatedFeatureClick?.('complexity_limit');
+                  }
+                }}
               >
                 <div className="text-center text-white p-6 max-w-xs">
                   <p className="text-lg font-semibold mb-2">

--- a/src/i18n/locales/ar/translation.json
+++ b/src/i18n/locales/ar/translation.json
@@ -393,7 +393,9 @@
     "shareNative": "مشاركة",
     "shareOnX": "مشاركة على X",
     "copyCaption": "نسخ التعليق",
-    "copied": "تم النسخ!"
+    "copied": "تم النسخ!",
+    "captionTemplate": "{{algorithm}}. تصور خطوة بخطوة من Bayan Flow.",
+    "titleTemplate": "تصور {{algorithm}} — Bayan Flow"
   },
   "complexity_panel": {
     "title": "تحليل التعقيد",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -394,7 +394,9 @@
     "shareNative": "Share",
     "shareOnX": "Share on X",
     "copyCaption": "Copy caption",
-    "copied": "Copied!"
+    "copied": "Copied!",
+    "captionTemplate": "{{algorithm}}. Step-by-step visualization from Bayan Flow.",
+    "titleTemplate": "{{algorithm}} Visualization — Bayan Flow"
   },
   "complexity_panel": {
     "title": "Complexity Analysis",

--- a/src/i18n/locales/fr/translation.json
+++ b/src/i18n/locales/fr/translation.json
@@ -369,9 +369,9 @@
     "sortOrder": "Basculer l'ordre initial du tableau pour le tri",
     "graphScenario": "Scénario de graphe",
     "randomGraph": "Graphe aléatoire",
-    "openSettings": "Réglages",
-    "closeSettings": "Fermer les réglages",
-    "settingsSheetTitle": "Réglages de l’algorithme",
+    "openSettings": "Paramètres",
+    "closeSettings": "Fermer les paramètres",
+    "settingsSheetTitle": "Paramètres de l'algorithme",
     "moreActions": "Plus d’actions"
   },
   "info": {
@@ -393,7 +393,9 @@
     "shareNative": "Partager",
     "shareOnX": "Partager sur X",
     "copyCaption": "Copier la légende",
-    "copied": "Copié !"
+    "copied": "Copié !",
+    "captionTemplate": "{{algorithm}}. Visualisation étape par étape depuis Bayan Flow.",
+    "titleTemplate": "Visualisation {{algorithm}} — Bayan Flow"
   },
   "complexity_panel": {
     "title": "Analyse de Complexité",

--- a/src/utils/focusableElements.js
+++ b/src/utils/focusableElements.js
@@ -1,0 +1,13 @@
+/**
+ * Returns an ordered list of focusable elements within a container,
+ * excluding disabled, hidden, and inert elements.
+ * @param {Element} container
+ * @returns {Element[]}
+ */
+export function getFocusableElements(container) {
+  const selector =
+    'button:not([disabled]), [href]:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"]):not([disabled]):not([hidden])';
+  return Array.from(container.querySelectorAll(selector)).filter(
+    el => !el.closest('[inert]') && el.offsetParent !== null
+  );
+}

--- a/src/utils/shareCaption.js
+++ b/src/utils/shareCaption.js
@@ -11,14 +11,18 @@ import { PRODUCTION_ORIGIN } from '../constants/siteSeo.js';
  * @param {string | null} algorithmName - Display name of the algorithm
  * @returns {{ caption: string, title: string, fullShareText: string }}
  */
-export function generateShareCaption(algorithmName) {
+export function generateShareCaption(algorithmName, t) {
   const name = algorithmName || 'Algorithm';
   const displayName = name.toLowerCase().endsWith('algorithm')
     ? name
     : `${name} Algorithm`;
 
-  const caption = `${displayName}. Step-by-step visualization from Bayan Flow.`;
-  const title = `${name} Visualization — Bayan Flow`;
+  const caption = t
+    ? t('shareExport.captionTemplate', { algorithm: displayName })
+    : `${displayName}. Step-by-step visualization from Bayan Flow.`;
+  const title = t
+    ? t('shareExport.titleTemplate', { algorithm: name })
+    : `${name} Visualization — Bayan Flow`;
   const fullShareText = `${caption}\n\n${PRODUCTION_ORIGIN}/app`;
 
   return { caption, title, fullShareText };


### PR DESCRIPTION
Resolves all 8 CodeRabbit review comments from PR #210:

1. **Complexity-limit overlay** (5 visualizers): Replaced invisible bg-black/30 dimming with opaque bg-black/80 blocking overlay + sign-in prompt text + click handler
2. **ErrorBoundary**: Added resetKey prop with componentDidUpdate recovery + visible fallback with "Something went wrong" + "Try again" button
3. **PythonCodePanel focus trap**: Moved querySelectorAll(FOCUSABLE) inside the keydown handler to avoid stale NodeList
4. **SettingsSheet focus trap**: Added Tab/Shift+Tab cycling in the existing useEffect keydown handler
5. **FR translation**: Fixed "Réglages" → "Paramètres" for settings-related keys
6. **Footer LICENSE link**: Replaced hardcoded develop-branch URL with GITHUB_REPO_URL/blob/main/LICENSE
7. **ShareExportModal localization**: Added t parameter to generateShareCaption(), with template keys in all 3 locales (en/fr/ar)
8. **ShareExportModal state reset**: Added useEffect to reset caption and copied state when modal opens

CI: lint ✓ | format ✓ | tests (1907/1907) ✓ | build ✓


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive, keyboard-accessible complexity limit prompts with localized guidance across visualizers.
  * Added a default error recovery screen with a “Try again” option and automatic recovery when content changes.
  * Added localized templates for share captions and titles.
* **Accessibility**
  * Improved keyboard focus management in settings, code panels, and gated feature prompts.
* **Bug Fixes**
  * Updated sharing text when reopening the export dialog.
  * Corrected the license link and refined French settings labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->