### PR TITLE
fix: pass Turnstile via captchaToken and stop broken before-signup metadata check

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,8 @@ VITE_SUPABASE_ANON_KEY=your-anon-key
 VITE_GOOGLE_WEB_CLIENT_ID=your-web-client-id.apps.googleusercontent.com
 
 # Cloudflare Turnstile (signup bot gate) — public site key only
-# Matching secret key is a Supabase Edge Function secret: TURNSTILE_SECRET_KEY
+# Matching secret key goes in Supabase Dashboard → Authentication → CAPTCHA
+# protection (Turnstile), NOT in a VITE_* var. Client sends it via captchaToken.
 VITE_TURNSTILE_SITE_KEY=0x4AAAAA...your-turnstile-site-key
 
 # PostHog analytics (optional — skip in local dev)

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -137,7 +137,10 @@ export async function signInWithGoogleIdToken(
   turnstileToken
 ) {
   const supabase = requireClient();
-  const /** @type {Record<string, any>} */ options = {
+  // signInWithIdToken does not accept user `data` metadata. Turnstile must go
+  // through options.captchaToken → gotrue_meta_security.captcha_token (verified
+  // by GoTrue when Auth CAPTCHA protection is enabled).
+  const /** @type {Record<string, any>} */ credentials = {
       provider: 'google',
       token: idToken,
       nonce,
@@ -145,10 +148,10 @@ export async function signInWithGoogleIdToken(
     };
 
   if (turnstileToken) {
-    options.data = { cf_turnstile_response: turnstileToken };
+    credentials.options = { captchaToken: turnstileToken };
   }
 
-  const { error } = await supabase.auth.signInWithIdToken(options);
+  const { error } = await supabase.auth.signInWithIdToken(credentials);
 
   if (error) {
     throw error;

--- a/src/services/authService.test.js
+++ b/src/services/authService.test.js
@@ -90,7 +90,7 @@ describe('authService', () => {
     });
   });
 
-  it('signInWithGoogleIdToken includes Turnstile token in user metadata when provided', async () => {
+  it('signInWithGoogleIdToken passes Turnstile token as captchaToken', async () => {
     await authService.signInWithGoogleIdToken(
       'token-123',
       undefined,
@@ -103,7 +103,7 @@ describe('authService', () => {
       token: 'token-123',
       nonce: undefined,
       access_token: undefined,
-      data: { cf_turnstile_response: 'turnstile-token' },
+      options: { captchaToken: 'turnstile-token' },
     });
   });
 
@@ -146,7 +146,7 @@ describe('authService', () => {
       token: 'google-id-token',
       nonce: undefined,
       access_token: undefined,
-      data: { cf_turnstile_response: 'cf-turnstile-ok' },
+      options: { captchaToken: 'cf-turnstile-ok' },
     });
   });
 

--- a/supabase/functions/before-signup/index.ts
+++ b/supabase/functions/before-signup/index.ts
@@ -49,45 +49,6 @@ function getServiceClient() {
   );
 }
 
-/**
- * Verify a Cloudflare Turnstile token via the siteverify endpoint.
- * Returns { success: boolean } — always succeeds if TURNSTILE_SECRET_KEY is
- * unset (graceful fallback for local dev or when Turnstile is not configured).
- */
-async function verifyTurnstileToken(
-  token: string | undefined
-): Promise<{ success: boolean }> {
-  const secretKey = Deno.env.get('TURNSTILE_SECRET_KEY');
-
-  if (!secretKey) {
-    return { success: true };
-  }
-
-  if (!token) {
-    return { success: false };
-  }
-
-  try {
-    const formData = new URLSearchParams();
-    formData.append('secret', secretKey);
-    formData.append('response', token);
-
-    const result = await fetch(
-      'https://challenges.cloudflare.com/turnstile/v0/siteverify',
-      {
-        method: 'POST',
-        body: formData,
-      }
-    );
-
-    const data = await result.json();
-    return { success: data.success === true };
-  } catch (err) {
-    console.error('before-signup: Turnstile verification error', err);
-    return { success: false };
-  }
-}
-
 export async function handleRequest(req) {
   if (req.method !== 'POST') {
     // Probes/scanners hit this URL with GET — log only, no Telegram noise.
@@ -127,14 +88,11 @@ export async function handleRequest(req) {
       return await reject('missing_ip');
     }
 
-    const turnstileToken = user.raw_user_meta_data?.cf_turnstile_response;
-    const turnstile = await verifyTurnstileToken(
-      typeof turnstileToken === 'string' ? turnstileToken : undefined
-    );
-
-    if (!turnstile.success) {
-      return await reject('turnstile_failed', { email, ip });
-    }
+    // Turnstile is NOT checked here. Google OIDC uses signInWithIdToken, which
+    // cannot attach custom raw_user_meta_data. The client sends the token as
+    // options.captchaToken; enable Auth → CAPTCHA protection (Turnstile) in the
+    // Supabase dashboard so GoTrue verifies it before this hook runs.
+    // This hook still enforces IP bans + signup rate limits.
 
     const supabase = getServiceClient();
 


### PR DESCRIPTION
# PR title:
fix: pass Turnstile via captchaToken and stop broken before-signup metadata check

---

## Contribution workflow

- [x] **Base branch is `develop`:** This PR targets **`develop`**, not `main`. (If the base is wrong, edit the PR on GitHub and change the base branch.)
- [x] **Guidelines and docs:** I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and the docs relevant to my change ([DEVELOPMENT.md](../docs/DEVELOPMENT.md), [ARCHITECTURE.md](../docs/ARCHITECTURE.md) as needed).
- [x] **This template:** I kept the PR template structure and filled in the sections below that apply to this change.

## Description

Follow-up to the Turnstile client wiring fix. Production/staging builds correctly included the Turnstile script, CSP, and site key, but **new Google signups still failed** with `before-signup` → `turnstile_failed` (confirmed in Auth logs at 2026-08-04 10:01 UTC from bayanflow.com).

**Root cause:** `supabase.auth.signInWithIdToken()` does **not** accept a top-level `data` / `raw_user_meta_data` payload. The client was setting `data: { cf_turnstile_response }`, which auth-js **ignores**. Only `options.captchaToken` is sent (as `gotrue_meta_security.captcha_token`). The hook never saw a token and always rejected.

**Fix:**
1. Pass the Turnstile token as `options: { captchaToken }`.
2. Remove the impossible `raw_user_meta_data.cf_turnstile_response` check from `before-signup` (IP bans + rate limits remain).
3. Bot CAPTCHA for OIDC should be verified by **GoTrue** — enable Auth CAPTCHA (Turnstile) in the Supabase dashboard with the Turnstile secret key.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] 🎨 Style/UI improvement
- [ ] ⚡ Performance improvement
- [x] 🧪 Test addition or improvement
- [ ] 🔧 Chore (maintenance, dependencies, etc.)

## Related Issues

Fixes #

## Changes Made

- `signInWithGoogleIdToken`: send Turnstile token via `options.captchaToken` (not ignored `data`).
- `before-signup`: remove custom Turnstile siteverify against user metadata (cannot work with Google OIDC id_token grant).
- Keep IP ban + signup rate-limit enforcement in `before-signup`.
- Update `.env.example` to point Turnstile **secret** at Supabase Auth CAPTCHA settings (not an edge-function-only path).
- Update `authService` unit tests for the captchaToken shape.

## Algorithm Details (if applicable)

N/A

## Testing

- [ ] All existing tests pass (`pnpm test:run`)
- [x] New tests added for new functionality
- [ ] Manual testing completed
- [ ] Cross-browser testing (if UI changes)

### Test Results

```
pnpm vitest run src/services/authService.test.js

 Test Files  1 passed (1)
      Tests  17 passed (17)
```

### Manual verification (post-deploy)

- [ ] New Google account signup succeeds on staging, then production.
- [ ] No `turnstile_failed` Telegram alert on successful signup.
- [ ] Existing account login still works.
- [ ] Optional: enable Supabase Auth → CAPTCHA protection (Turnstile) so GoTrue verifies `captchaToken`.

## Screenshots/GIFs

N/A

## Code Quality

- [x] Code follows the project's coding standards
- [ ] ESLint passes (`pnpm lint`)
- [x] Prettier formatting applied (`pnpm format`)
- [x] No console errors or warnings
- [x] Code is properly documented with JSDoc (if applicable)

## Performance Impact

- [x] No performance impact
- [ ] Performance improved
- [ ] Performance impact assessed and acceptable
- [ ] Performance benchmarks included

## Accessibility

N/A

## Breaking Changes

- None. `TURNSTILE_SECRET_KEY` on the edge function is unused after this change; Auth CAPTCHA (dashboard) is the correct place for the Turnstile secret if you want GoTrue-side verification.

## Checklist

- [x] I have completed the **Contribution workflow** checklist at the top of this template
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

- Redeploy alone could not fix this: the previous PR correctly shipped the client widget, but the token was never attached to the id_token request in a way GoTrue/the hook could use.
- After merge: deploy SPA + redeploy `before-signup`. Then try a **new** Google account (existing accounts never hit Before User Created).
- Recommended ops: Supabase Dashboard → Authentication → Bot and Abuse Protection → Enable CAPTCHA → Cloudflare Turnstile → paste the Turnstile **secret** key.

---

**Reviewer Guidelines:**
- Check that all tests pass
- Verify code follows project standards
- Review for security implications (CAPTCHA now depends on GoTrue settings + client captchaToken)
- Ensure documentation is updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CAPTCHA handling during Google sign-in and account registration.
  * CAPTCHA verification is now processed more reliably by the authentication service.
  * Existing IP-based blocking and rate limiting remain in place to help prevent abuse.

* **Documentation**
  * Updated configuration guidance to clarify where the CAPTCHA secret is managed and how verification tokens are submitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->